### PR TITLE
CI: use Go version from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          check-latest: true
           cache: true
       - name: Test
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: go.mod
+          cache: true
+      - name: Test
+        run: go test ./...
       - name: Build
         run: go build ./cmd/ghx


### PR DESCRIPTION
Updates CI to use the Go version declared in go.mod (currently 1.24.0) and adds a test step (go test ./...).\n\nCloses #15 (CI checkbox items).