### PR TITLE
CI: run go test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'
+      - name: Test
+        run: go test ./...
       - name: Build
         run: go build ./cmd/ghx


### PR DESCRIPTION
Fixes #15

Adds a `go test ./...` step to the CI workflow so PRs run unit tests in addition to building.

Notes:
- Local: `go test ./...` (pass)
- CI: uses Go 1.21.x per existing config