### PR TITLE
Docs: document ghx board flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ A thin wrapper around GitHub CLI (`gh`) with extra visualizations.
 Features
 - Pass-through to `gh` for all commands
 - `ghx issue tree` renders parent-child issue trees
+- `ghx issue tree` flags: `--open`, `--closed`, `--root <title|#id|id>`, `--link`
 - `ghx board` opens a full-screen Kanban board for issues
-- Flags: `--open`, `--closed`, `--root <title|#id|id>`, `--link`
+- `ghx board` flags: `--state <open|closed|all>` (default: `open`), `--limit <n>` (default: `200`)
 - Bug and blocked labels rendered inline
 - Styled output using charmbracelet/lipgloss with adaptive theme (automatically switches between light and dark mode based on terminal background)
 
@@ -21,6 +22,8 @@ Usage
 - `ghx issue tree --root 399`
 - `ghx issue tree --link` (show issue URLs)
 - `ghx board`
+- `ghx board --state closed`
+- `ghx board --state all --limit 500`
 
 Notes
 - Parent relationship from GitHub's native sub-issue feature

--- a/cmd/ghx/board_docs_test.go
+++ b/cmd/ghx/board_docs_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	t.Cleanup(func() {
+		_ = w.Close()
+		_ = r.Close()
+		os.Stdout = old
+	})
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("io.ReadAll: %v", err)
+	}
+	return string(out)
+}
+
+func readRepoFile(t *testing.T, repoRelativePath string) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// This file lives in cmd/ghx; repo root is two levels up.
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+
+	b, err := os.ReadFile(filepath.Join(repoRoot, repoRelativePath))
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q): %v", repoRelativePath, err)
+	}
+	return string(b)
+}
+
+func TestBoardHelpDocumentsFlags(t *testing.T) {
+	out := captureStdout(t, func() {
+		if code := runBoard([]string{"--help"}); code != 0 {
+			t.Fatalf("runBoard(--help) = %d, want 0", code)
+		}
+	})
+
+	for _, want := range []string{"--state", "--limit", "<open|closed|all>"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("help output missing %q\n\n%s", want, out)
+		}
+	}
+}
+
+func TestReadmeDocumentsBoardFlags(t *testing.T) {
+	readme := readRepoFile(t, "README.md")
+	for _, want := range []string{"`ghx board --state closed`", "`ghx board --state all --limit 500`"} {
+		if !strings.Contains(readme, want) {
+			t.Fatalf("README.md missing %q", want)
+		}
+	}
+}
+


### PR DESCRIPTION
Documents `ghx board` flags (`--state`, `--limit`) in `README.md` and adds a small regression test.

- Adds examples: `ghx board --state closed`, `ghx board --state all --limit 500`
- Adds tests that assert `ghx board --help` and `README.md` mention the flags

Tests: `go test ./...`

Context: Asynkron/asynkron.githubclix#15 (closed), Asynkron/asynkron.githubclix#16